### PR TITLE
Add CSV upload with history using Drizzle ORM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fontsource/inter": "^5.2.6",
+        "better-sqlite3": "^12.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.44.4",
@@ -19,7 +20,8 @@
         "react-dom": "19.1.0",
         "sqlite3": "^5.1.7",
         "tailwind-merge": "^3.3.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^4.0.14"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2350,6 +2352,20 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.2.0.tgz",
+      "integrity": "sha512-eGbYq2CT+tos1fBwLQ/tkBt9J5M3JEHjku4hbvQUePCckkvVf14xWj+1m7dGoK81M/fOjFT7yM9UMeKT/+vFLQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
+      }
     },
     "node_modules/bindings": {
       "version": "1.5.0",
@@ -8038,6 +8054,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.14.tgz",
+      "integrity": "sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.6",
+    "better-sqlite3": "^12.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.44.4",
@@ -20,7 +21,8 @@
     "react-dom": "19.1.0",
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^3.3.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "zod": "^4.0.14"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/api/upload/[uploadId]/load/route.ts
+++ b/src/app/api/upload/[uploadId]/load/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { uploads } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { uploadId: string } }
+) {
+  const entry = await db
+    .select()
+    .from(uploads)
+    .where(eq(uploads.id, params.uploadId));
+
+  if (!entry.length) {
+    return new NextResponse('Not Found', { status: 404 });
+  }
+
+  return NextResponse.json(JSON.parse(entry[0].content));
+}

--- a/src/app/api/upload/history/route.ts
+++ b/src/app/api/upload/history/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { uploads } from '@/lib/schema';
+import { desc } from 'drizzle-orm';
+
+export async function GET() {
+  const entries = await db.select().from(uploads).orderBy(desc(uploads.uploadedAt));
+  return NextResponse.json(entries);
+}

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { v4 as uuidv4 } from 'uuid';
+import { db } from '@/lib/db';
+import { uploads, products } from '@/lib/schema';
+import { parseCsv } from '@/lib/parseCsv';
+import { z } from 'zod';
+
+const ProductSchema = z.object({
+  sku: z.string(),
+  name: z.string(),
+  type: z.enum(['parent', 'variation']),
+  price: z.number().optional(),
+  category: z.string().optional().nullable(),
+  stockStatus: z.string().optional().nullable(),
+  parentSku: z.string().optional().nullable(),
+  attributes: z.record(z.any()).optional().nullable(),
+});
+
+export async function POST(request: Request) {
+  const formData = await request.formData();
+  const files = formData.getAll('files') as File[];
+  const ids: string[] = [];
+
+  for (const file of files) {
+    const text = await file.text();
+    const fileType = file.name.toLowerCase().includes('variation') ? 'variation' : 'parent';
+    const productsData = parseCsv(text, fileType);
+    const valid = z.array(ProductSchema).parse(productsData);
+    const id = uuidv4();
+
+    await db.insert(uploads).values({
+      id,
+      filename: file.name,
+      type: fileType,
+      content: JSON.stringify(valid),
+      uploadedAt: new Date(),
+    });
+
+    if (valid.length > 0) {
+      const rows = valid.map((p) => ({
+        sku: p.sku,
+        name: p.name,
+        type: p.type,
+        price: p.price ?? null,
+        category: p.category ?? null,
+        stockStatus: p.stockStatus ?? null,
+        parentSku: p.parentSku ?? null,
+        attributes: p.attributes ? JSON.stringify(p.attributes) : null,
+      }));
+      await db.insert(products).values(rows);
+    }
+
+    ids.push(id);
+  }
+
+  return NextResponse.json({ ids });
+}

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -1,0 +1,12 @@
+import UploadDropzone from '@/components/UploadDropzone';
+import CsvUploadHistory from '@/components/CsvUploadHistory';
+
+export default function UploadPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Upload CSV</h1>
+      <UploadDropzone />
+      <CsvUploadHistory />
+    </div>
+  );
+}

--- a/src/components/CsvUploadHistory.tsx
+++ b/src/components/CsvUploadHistory.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { UploadEntry } from '@/lib/types';
+
+export default function CsvUploadHistory() {
+  const [entries, setEntries] = useState<UploadEntry[]>([]);
+
+  useEffect(() => {
+    fetch('/api/upload/history')
+      .then((res) => res.json())
+      .then(setEntries);
+  }, []);
+
+  return (
+    <div className="mt-4">
+      <h2 className="font-bold mb-2">Previous uploads</h2>
+      <ul className="space-y-1">
+        {entries.map((e) => (
+          <li key={e.id} className="text-sm">
+            {e.filename} - {e.type} -{' '}
+            {new Date(e.uploadedAt).toLocaleString()}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/UploadDropzone.tsx
+++ b/src/components/UploadDropzone.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function UploadDropzone() {
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files?.length) return;
+
+    const formData = new FormData();
+    Array.from(files).forEach((file) => formData.append('files', file));
+    setLoading(true);
+    const res = await fetch('/api/upload', {
+      method: 'POST',
+      body: formData,
+    });
+    if (res.ok) {
+      setMessage('Uploaded');
+    } else {
+      setMessage('Error');
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <input
+        type="file"
+        accept=".csv"
+        multiple
+        onChange={handleChange}
+        disabled={loading}
+      />
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,0 +1,7 @@
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import Database from 'better-sqlite3';
+import { join } from 'path';
+import * as schema from './schema';
+
+const sqlite = new Database(join(process.cwd(), 'sqlite.db'));
+export const db = drizzle(sqlite, { schema });

--- a/src/lib/parseCsv.ts
+++ b/src/lib/parseCsv.ts
@@ -1,0 +1,20 @@
+import Papa from 'papaparse';
+import { Product } from './types';
+
+export function parseCsv(content: string, type: 'parent' | 'variation'): Product[] {
+  const parsed = Papa.parse<Record<string, string>>(content, {
+    header: true,
+    skipEmptyLines: true,
+  });
+
+  return parsed.data.map((row) => ({
+    sku: row.sku || '',
+    name: row.name || '',
+    type,
+    price: row.price ? Number(row.price) : undefined,
+    category: row.category || undefined,
+    stockStatus: row.stockStatus || undefined,
+    parentSku: row.parentSku || undefined,
+    attributes: row.attributes ? JSON.parse(row.attributes) : undefined,
+  }));
+}

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,21 @@
+import { sqliteTable, text, integer, real } from 'drizzle-orm/sqlite-core';
+
+export const uploads = sqliteTable('uploads', {
+  id: text('id').primaryKey(),
+  filename: text('filename').notNull(),
+  type: text('type', { enum: ['parent', 'variation'] }).notNull(),
+  content: text('content').notNull(),
+  uploadedAt: integer('uploaded_at', { mode: 'timestamp' }).notNull(),
+});
+
+export const products = sqliteTable('products', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  sku: text('sku').notNull(),
+  name: text('name').notNull(),
+  type: text('type', { enum: ['parent', 'variation'] }).notNull(),
+  price: real('price'),
+  category: text('category'),
+  stockStatus: text('stock_status'),
+  parentSku: text('parent_sku'),
+  attributes: text('attributes'),
+});

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,18 @@
+export type Product = {
+  sku: string;
+  name: string;
+  type: 'parent' | 'variation';
+  price?: number;
+  category?: string | null;
+  stockStatus?: string | null;
+  parentSku?: string | null;
+  attributes?: Record<string, unknown> | null;
+};
+
+export type UploadEntry = {
+  id: string;
+  filename: string;
+  type: 'parent' | 'variation';
+  content: Product[];
+  uploadedAt: Date;
+};


### PR DESCRIPTION
## Summary
- use better-sqlite3 driver with Drizzle
- define `uploads` and `products` tables
- create CSV parser utility
- add upload API routes
- build `UploadDropzone` and `CsvUploadHistory` components
- expose `/upload` page for CSV upload

## Testing
- `npm run lint`
- `npm run build` *(fails: failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688d3bde8a048333823e208689897f95