### PR TITLE
Fix references and add products API

### DIFF
--- a/src/app/api/products/route.ts
+++ b/src/app/api/products/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { products as productsTable } from '@/lib/schema';
+
+export async function GET() {
+  const data = await db.select().from(productsTable);
+  return NextResponse.json(data);
+}

--- a/src/app/api/shops/route.ts
+++ b/src/app/api/shops/route.ts
@@ -1,13 +1,14 @@
 // src/app/api/shops/route.ts
 import { NextResponse } from 'next/server';
+import type { ShopConfig } from '@/lib/wooApi';
 
 export async function GET() {
   const raw = process.env.SHOP_CONFIGS;
   if (!raw) return NextResponse.json([], { status: 200 });
 
   try {
-    const shops = JSON.parse(raw);
-    const output = shops.map((s: any) => ({ id: s.id, name: s.name }));
+    const shops: ShopConfig[] = JSON.parse(raw);
+    const output = shops.map((s) => ({ id: s.id, name: s.name }));
     return NextResponse.json(output);
   } catch {
     return NextResponse.json({ error: 'Ugyldig SHOP_CONFIGS' }, { status: 500 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -16,10 +16,6 @@ type Product = {
   selected?: boolean;
 };
 
-type Shop = {
-  id: string;
-  name: string;
-};
 
 export default function SyncPage() {
   const [products, setProducts] = useState<Product[]>([]);
@@ -27,7 +23,7 @@ export default function SyncPage() {
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
-    fetch('/api/products') // Du skal lave denne route separat
+    fetch('/api/products')
       .then((res) => res.json())
       .then((data) => setProducts(data))
       .catch(() => toast.error('Kunne ikke hente produkter'));
@@ -60,7 +56,7 @@ export default function SyncPage() {
       } else {
         toast.error(result.error || 'Fejl ved synkronisering');
       }
-    } catch (err) {
+    } catch {
       toast.error('Netværksfejl ved sync');
     } finally {
       setIsLoading(false);

--- a/src/app/sync/page.tsx
+++ b/src/app/sync/page.tsx
@@ -1,10 +1,8 @@
 import { db } from '@/lib/db';
 import { products as productsTable } from '@/lib/schema';
 import SyncClient from '@/components/SyncClient';
-import { getShopConfigs } from '@/lib/wooApi';
 
 export default async function SyncPage() {
   const products = await db.select().from(productsTable);
-  const shops = getShopConfigs();
-  return <SyncClient products={products} shops={shops} />;
+  return <SyncClient products={products} />;
 }

--- a/src/components/ShopSelector.tsx
+++ b/src/components/ShopSelector.tsx
@@ -39,4 +39,6 @@ export function ShopSelector({ selected, onChange }: Props) {
           ))}
         </SelectContent>
       </Select>
-    </div
+    </div>
+  );
+}

--- a/src/components/SyncClient.tsx
+++ b/src/components/SyncClient.tsx
@@ -2,23 +2,29 @@
 
 import { useState } from 'react';
 import { Product } from '@/lib/types';
-import { ShopConfig } from '@/lib/wooApi';
-import ProductTable from './ProductTable';
-import ShopSelector from './ShopSelector';
+import { ProductTable } from './ProductTable';
+import { ShopSelector } from './ShopSelector';
 import SyncResultModal from './SyncResultModal';
 
 type Row = Product & { id: number; selected?: boolean };
 
 type Props = {
   products: Row[];
-  shops: ShopConfig[];
 };
 
-export default function SyncClient({ products, shops }: Props) {
+export default function SyncClient({ products }: Props) {
   const [rows, setRows] = useState<Row[]>(products);
   const [shopId, setShopId] = useState('');
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<null | { sku: string; success: boolean; error?: string }[]>(null);
+
+  const toggleRow = (id: number) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, selected: !r.selected } : r)));
+  };
+
+  const updateRow = (id: number, data: Partial<Row>) => {
+    setRows((prev) => prev.map((r) => (r.id === id ? { ...r, ...data } : r)));
+  };
 
   const handleSync = async () => {
     const selected = rows.filter((r) => r.selected);
@@ -43,8 +49,12 @@ export default function SyncClient({ products, shops }: Props) {
 
   return (
     <div className="space-y-4">
-      <ShopSelector shops={shops} value={shopId} onChange={setShopId} />
-      <ProductTable products={rows} onChange={setRows} />
+      <ShopSelector selected={shopId} onChange={setShopId} />
+      <ProductTable
+        products={rows}
+        onToggleSelect={toggleRow}
+        onUpdateProduct={updateRow}
+      />
       <button className="border rounded px-4 py-2" disabled={loading} onClick={handleSync}>
         {loading ? 'Syncing...' : 'Send til WooCommerce'}
       </button>

--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -8,6 +8,19 @@ export type WooShop = {
   consumer_secret: string;
 };
 
+export type ShopConfig = WooShop;
+
+export function getShopConfigs(): WooShop[] {
+  const raw = process.env.SHOP_CONFIGS;
+  if (!raw) return [];
+
+  try {
+    return JSON.parse(raw) as WooShop[];
+  } catch {
+    return [];
+  }
+}
+
 export function getShopConfig(shopId: string): WooShop | null {
   const raw = process.env.SHOP_CONFIGS;
   if (!raw) return null;


### PR DESCRIPTION
## Summary
- correct `ShopSelector` component markup
- fix `SyncClient` logic and update imports
- remove unused shop loading from `/sync` page
- add `getShopConfigs()` helper
- improve WooCommerce sync error handling
- implement `/api/products` route
- clean up client page code

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font files)*

------
https://chatgpt.com/codex/tasks/task_e_688d46dc1ac8833382eb180f74ef1c35