### PR TITLE
Add basic UI components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "papaparse": "^5.5.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "sonner": "^2.0.6",
         "sqlite3": "^5.1.7",
         "tailwind-merge": "^3.3.1",
         "uuid": "^11.1.0",
@@ -7181,6 +7182,16 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.6.tgz",
+      "integrity": "sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@fontsource/inter": "^5.2.6",
+    "axios": "^1.6.8",
     "better-sqlite3": "^12.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -19,11 +20,11 @@
     "papaparse": "^5.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "sonner": "^2.0.6",
     "sqlite3": "^5.1.7",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.1.0",
-    "zod": "^4.0.14",
-    "axios": "^1.6.8"
+    "zod": "^4.0.14"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/components/ShopSelector.tsx
+++ b/src/components/ShopSelector.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from 'react';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
 type Shop = {
   id: string;
@@ -27,18 +26,21 @@ export function ShopSelector({ selected, onChange }: Props) {
   return (
     <div className="space-y-1">
       <Label htmlFor="shop">Vælg webshop</Label>
-      <Select value={selected ?? ''} onValueChange={onChange}>
-        <SelectTrigger id="shop" className="w-64">
-          <SelectValue placeholder="Vælg en shop" />
-        </SelectTrigger>
-        <SelectContent>
-          {shops.map((shop) => (
-            <SelectItem key={shop.id} value={shop.id}>
-              {shop.name}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+      <select
+        id="shop"
+        className="w-64 border rounded px-3 py-2"
+        value={selected ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value="" disabled>
+          Vælg en shop
+        </option>
+        {shops.map((shop) => (
+          <option key={shop.id} value={shop.id}>
+            {shop.name}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(
+          'inline-flex items-center justify-center rounded-md border bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90 disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = 'Button';
+

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      type="checkbox"
+      ref={ref}
+      className={cn('size-4 accent-primary rounded', className)}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = 'Checkbox';
+

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn('border rounded px-3 py-2', className)}
+      {...props}
+    />
+  )
+);
+Input.displayName = 'Input';
+

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn('text-sm font-medium', className)} {...props} />
+  )
+);
+Label.displayName = 'Label';
+

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,40 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {}
+export interface TableHeaderProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
+export interface TableBodyProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
+export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement> {}
+export interface TableHeadProps extends React.ThHTMLAttributes<HTMLTableCellElement> {}
+export interface TableCellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {}
+
+export const Table = React.forwardRef<HTMLTableElement, TableProps>(({ className, ...props }, ref) => (
+  <table ref={ref} className={cn('w-full text-sm', className)} {...props} />
+));
+Table.displayName = 'Table';
+
+export const TableHeader = React.forwardRef<HTMLTableSectionElement, TableHeaderProps>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+export const TableBody = React.forwardRef<HTMLTableSectionElement, TableBodyProps>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={className} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+export const TableRow = React.forwardRef<HTMLTableRowElement, TableRowProps>(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b last:border-b-0', className)} {...props} />
+));
+TableRow.displayName = 'TableRow';
+
+export const TableHead = React.forwardRef<HTMLTableCellElement, TableHeadProps>(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn('px-3 py-2 text-left font-semibold', className)} {...props} />
+));
+TableHead.displayName = 'TableHead';
+
+export const TableCell = React.forwardRef<HTMLTableCellElement, TableCellProps>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn('px-3 py-2', className)} {...props} />
+));
+TableCell.displayName = 'TableCell';
+


### PR DESCRIPTION
## Summary
- include missing UI components (Button, Input, Checkbox, Label, Table)
- replace custom `Select` component usage with basic HTML `<select>`
- add `sonner` dependency for toast notifications

## Testing
- `npm run build` *(fails: Failed to fetch fonts from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_688d49e0ba3883338d202404fe762e1f