### PR TITLE
Initialize SQLite tables using schema

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -2,6 +2,8 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
 import { join } from 'path';
 import * as schema from './schema';
+import { initDb } from './initDb';
 
 const sqlite = new Database(join(process.cwd(), 'sqlite.db'));
+initDb(sqlite);
 export const db = drizzle(sqlite, { schema });

--- a/src/lib/initDb.ts
+++ b/src/lib/initDb.ts
@@ -1,0 +1,23 @@
+import Database from 'better-sqlite3';
+
+export function initDb(db: Database.Database) {
+  db.exec(`CREATE TABLE IF NOT EXISTS uploads (
+    id TEXT PRIMARY KEY,
+    filename TEXT NOT NULL,
+    type TEXT NOT NULL,
+    content TEXT NOT NULL,
+    uploaded_at INTEGER NOT NULL
+  );`);
+
+  db.exec(`CREATE TABLE IF NOT EXISTS products (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    sku TEXT NOT NULL,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,
+    price REAL,
+    category TEXT,
+    stock_status TEXT,
+    parent_sku TEXT,
+    attributes TEXT
+  );`);
+}


### PR DESCRIPTION
## Summary
- create `initDb` helper that creates `uploads` and `products` tables
- invoke `initDb` when establishing the database connection

## Testing
- `npm run lint` *(fails: interface declaring no members is equivalent to its supertype)*
- `npm run build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_688d4ce972348333a096c9cc423a62eb