### PR TITLE
Fix getShopConfigs and remove duplicate export

### DIFF
--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -19,8 +19,8 @@ export function getShopConfigs(): WooShop[] {
   } catch {
     return [];
   }
+}
 
-export async function fetchWooProducts(shop: WooShop) {
 export async function fetchWooProducts(shop: WooShop) {
   const client = getWooClient(shop);
   try {


### PR DESCRIPTION
## Summary
- close `getShopConfigs` with the missing brace
- remove duplicate `fetchWooProducts` export

## Testing
- `npx tsc src/lib/wooApi.ts --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688d58b6b0888333bbd077136d3f9825