### PR TITLE
Fix wooApi types and successful build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,9 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^20",
+        "@types/papaparse": "^5.3.16",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -1355,6 +1357,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1380,10 +1392,20 @@
       "version": "20.19.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
       "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.3.16",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.3.16.tgz",
+      "integrity": "sha512-T3VuKMC2H0lgsjI9buTB3uuKj3EMD2eap1MOuEQuBQ44EnDx/IkGhU6EwiTf9zG3za4SKlmwKAImdDKdNnCsXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -7914,7 +7936,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unique-filename": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^20",
+    "@types/papaparse": "^5.3.16",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/src/app/api/upload/[uploadId]/load/route.ts
+++ b/src/app/api/upload/[uploadId]/load/route.ts
@@ -1,12 +1,13 @@
-import { NextResponse } from 'next/server';
+import { NextResponse, NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { uploads } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
 
 export async function GET(
-  request: Request,
-  { params }: { params: { uploadId: string } }
+  request: NextRequest,
+  context: { params: Promise<{ uploadId: string }> }
 ) {
+  const params = await context.params;
   const entry = await db
     .select()
     .from(uploads)

--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -13,7 +13,7 @@ const ProductSchema = z.object({
   category: z.string().optional().nullable(),
   stockStatus: z.string().optional().nullable(),
   parentSku: z.string().optional().nullable(),
-  attributes: z.record(z.any()).optional().nullable(),
+  attributes: z.record(z.string(), z.any()).optional().nullable(),
 });
 
 export async function POST(request: Request) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import type { WooProduct } from '@/lib/wooApi';
 // Custom toast implementation
 const toast = {
   success: (message: string) => {
@@ -40,19 +41,7 @@ import {
   X
 } from 'lucide-react';
 
-type Product = {
-  id: number;
-  sku: string;
-  name: string;
-  price: number;
-  category?: string;
-  type: 'parent' | 'variation';
-  parentId?: number;
-  selected?: boolean;
-  stock?: number;
-  status?: 'publish' | 'draft' | 'private';
-  image?: string;
-};
+type Product = WooProduct;
 
 type Shop = {
   id: string;
@@ -179,8 +168,9 @@ export default function WooCommerceManager() {
         s.id === selectedShop ? { ...s, lastSync: new Date().toISOString() } : s
       ));
       toast.success('Produkter synkroniseret!');
-    } catch (err: any) {
-      toast.error('Fejl ved synkronisering: ' + (err?.message || 'Ukendt fejl'));
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Ukendt fejl';
+      toast.error('Fejl ved synkronisering: ' + message);
     } finally {
       setIsLoading(false);
     }
@@ -413,7 +403,7 @@ export default function WooCommerceManager() {
                                   <div className="flex-1">
                                     <div className="flex items-center gap-3 mb-1">
                                       <h4 className="font-medium text-gray-800">{variation.name}</h4>
-                                      <Badge variant="outline" size="sm">
+                                      <Badge variant="outline">
                                         Variant
                                       </Badge>
                                     </div>

--- a/src/app/sync/page.tsx
+++ b/src/app/sync/page.tsx
@@ -1,8 +1,21 @@
 import { db } from '@/lib/db';
 import { products as productsTable } from '@/lib/schema';
 import SyncClient from '@/components/SyncClient';
+import type { WooProduct } from '@/lib/wooApi';
 
 export default async function SyncPage() {
-  const products = await db.select().from(productsTable);
+  const raw = await db.select().from(productsTable);
+  const products: WooProduct[] = raw.map((p) => ({
+    id: p.id,
+    sku: p.sku,
+    name: p.name,
+    price: p.price ?? 0,
+    category: p.category ?? undefined,
+    type: p.type,
+    parentId: undefined,
+    stock: undefined,
+    status: p.stockStatus ?? undefined,
+    image: undefined,
+  }));
   return <SyncClient products={products} />;
 }

--- a/src/components/ProductTable.tsx
+++ b/src/components/ProductTable.tsx
@@ -3,16 +3,9 @@
 import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import type { WooProduct } from '@/lib/wooApi';
 
-type Product = {
-  id: number;
-  sku: string;
-  name: string;
-  price: number;
-  category?: string;
-  type: 'parent' | 'variation';
-  selected?: boolean;
-};
+type Product = WooProduct & { selected?: boolean };
 
 type Props = {
   products: Product[];
@@ -40,7 +33,7 @@ export function ProductTable({ products, onToggleSelect, onUpdateProduct }: Prop
               <TableCell>
                 <Checkbox
                   checked={product.selected}
-                  onCheckedChange={() => onToggleSelect(product.id)}
+                  onChange={() => onToggleSelect(product.id)}
                 />
               </TableCell>
               <TableCell className="text-xs">{product.sku}</TableCell>

--- a/src/components/SyncClient.tsx
+++ b/src/components/SyncClient.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { Product } from '@/lib/types';
+import type { WooProduct } from '@/lib/wooApi';
 import { ProductTable } from './ProductTable';
 import { ShopSelector } from './ShopSelector';
 import SyncResultModal from './SyncResultModal';
 
-type Row = Product & { id: number; selected?: boolean };
+type Row = WooProduct & { selected?: boolean };
 
 type Props = {
   products: Row[];

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { cn } from '@/lib/utils';
 
 export function Badge({ className, variant = 'default', ...props }: React.HTMLAttributes<HTMLSpanElement> & { variant?: 'default' | 'secondary' | 'outline' | 'destructive'; }) {
-  let base = 'inline-block px-3 py-1 rounded-full text-xs font-medium';
-  let variants: Record<string, string> = {
+  const base = 'inline-block px-3 py-1 rounded-full text-xs font-medium';
+  const variants: Record<string, string> = {
     default: 'bg-blue-100 text-blue-800',
     secondary: 'bg-gray-100 text-gray-600',
     outline: 'border border-gray-300 text-gray-800',

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
   ({ className, ...props }, ref) => (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, ...props }, ref) => (

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
 
 export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
   ({ className, ...props }, ref) => (

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
 
-export interface TableProps extends React.TableHTMLAttributes<HTMLTableElement> {}
-export interface TableHeaderProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
-export interface TableBodyProps extends React.HTMLAttributes<HTMLTableSectionElement> {}
-export interface TableRowProps extends React.HTMLAttributes<HTMLTableRowElement> {}
-export interface TableHeadProps extends React.ThHTMLAttributes<HTMLTableCellElement> {}
-export interface TableCellProps extends React.TdHTMLAttributes<HTMLTableCellElement> {}
+export type TableProps = React.TableHTMLAttributes<HTMLTableElement>;
+export type TableHeaderProps = React.HTMLAttributes<HTMLTableSectionElement>;
+export type TableBodyProps = React.HTMLAttributes<HTMLTableSectionElement>;
+export type TableRowProps = React.HTMLAttributes<HTMLTableRowElement>;
+export type TableHeadProps = React.ThHTMLAttributes<HTMLTableCellElement>;
+export type TableCellProps = React.TdHTMLAttributes<HTMLTableCellElement>;
 
 export const Table = React.forwardRef<HTMLTableElement, TableProps>(({ className, ...props }, ref) => (
   <table ref={ref} className={cn('w-full text-sm', className)} {...props} />

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,7 +2,7 @@ export type Product = {
   sku: string;
   name: string;
   type: 'parent' | 'variation';
-  price?: number;
+  price?: number | null;
   category?: string | null;
   stockStatus?: string | null;
   parentSku?: string | null;

--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -1,5 +1,31 @@
 import axios from 'axios';
 
+interface WooProductData {
+  id: number;
+  sku: string;
+  name: string;
+  price: number;
+  categories?: { name: string }[];
+  variations?: unknown[];
+  parent_id?: number;
+  stock_quantity?: number;
+  status?: string;
+  images?: { src: string }[];
+}
+
+export type WooProduct = {
+  id: number;
+  sku: string;
+  name: string;
+  price: number;
+  category?: string;
+  type: 'parent' | 'variation';
+  parentId?: number;
+  stock?: number;
+  status?: string;
+  image?: string;
+};
+
 export type WooShop = {
   id: string;
   name: string;
@@ -21,13 +47,13 @@ export function getShopConfigs(): WooShop[] {
   }
 }
 
-export async function fetchWooProducts(shop: WooShop) {
+export async function fetchWooProducts(shop: WooShop): Promise<WooProduct[]> {
   const client = getWooClient(shop);
   try {
     const res = await client.get('/products');
-    const data = res.data;
+    const data = res.data as WooProductData[];
     // Map WooCommerce products to local Product type
-    return data.map((p: any) => ({
+    return data.map((p): WooProduct => ({
       id: p.id,
       sku: p.sku,
       name: p.name,
@@ -39,7 +65,7 @@ export async function fetchWooProducts(shop: WooShop) {
       status: p.status,
       image: p.images?.[0]?.src,
     }));
-  } catch (err) {
+  } catch (err: unknown) {
     throw err;
   }
 }


### PR DESCRIPTION
## Summary
- add explicit WooCommerce product types
- align UI component props with new types
- parse DB rows for sync page
- adjust components to satisfy TypeScript rules
- add missing type packages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688d59957b2c8333962de2a0cdd501ff