### PR TITLE
Fetch products from WooCommerce when selecting a shop

### DIFF
--- a/src/app/api/woo/products/route.ts
+++ b/src/app/api/woo/products/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getShopConfig, fetchWooProducts } from '@/lib/wooApi';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const shopId = searchParams.get('shopId');
+  if (!shopId) {
+    return NextResponse.json({ error: 'Missing shopId' }, { status: 400 });
+  }
+  const shop = getShopConfig(shopId);
+  if (!shop) {
+    return NextResponse.json({ error: 'Shop not found' }, { status: 404 });
+  }
+  try {
+    const products = await fetchWooProducts(shop);
+    return NextResponse.json(products);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/sync/page.tsx
+++ b/src/app/sync/page.tsx
@@ -1,21 +1,5 @@
-import { db } from '@/lib/db';
-import { products as productsTable } from '@/lib/schema';
 import SyncClient from '@/components/SyncClient';
-import type { WooProduct } from '@/lib/wooApi';
 
-export default async function SyncPage() {
-  const raw = await db.select().from(productsTable);
-  const products: WooProduct[] = raw.map((p) => ({
-    id: p.id,
-    sku: p.sku,
-    name: p.name,
-    price: p.price ?? 0,
-    category: p.category ?? undefined,
-    type: p.type,
-    parentId: undefined,
-    stock: undefined,
-    status: p.stockStatus ?? undefined,
-    image: undefined,
-  }));
-  return <SyncClient products={products} />;
+export default function SyncPage() {
+  return <SyncClient />;
 }

--- a/src/components/ProductTable.tsx
+++ b/src/components/ProductTable.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import type { WooProduct } from '@/lib/wooApi';
@@ -10,54 +9,58 @@ type Product = WooProduct & { selected?: boolean };
 type Props = {
   products: Product[];
   onToggleSelect: (id: number) => void;
-  onUpdateProduct: (id: number, data: Partial<Product>) => void;
 };
 
-export function ProductTable({ products, onToggleSelect, onUpdateProduct }: Props) {
+export function ProductTable({ products, onToggleSelect }: Props) {
   return (
     <div className="rounded border overflow-x-auto">
       <Table>
         <TableHeader>
           <TableRow>
             <TableHead></TableHead>
-            <TableHead>SKU</TableHead>
             <TableHead>Navn</TableHead>
+            <TableHead>SKU</TableHead>
+            <TableHead>Status</TableHead>
             <TableHead>Pris</TableHead>
+            <TableHead>Farve</TableHead>
+            <TableHead>Størrelse</TableHead>
+            <TableHead>Brand</TableHead>
             <TableHead>Kategori</TableHead>
-            <TableHead>Type</TableHead>
+            <TableHead>Billede</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {products.map((product) => (
-            <TableRow key={product.id} className={product.type === 'variation' ? 'bg-muted/30' : ''}>
+            <TableRow
+              key={product.id}
+              className={product.type === 'variation' ? 'bg-muted/30' : ''}
+            >
               <TableCell>
                 <Checkbox
                   checked={product.selected}
                   onChange={() => onToggleSelect(product.id)}
                 />
               </TableCell>
-              <TableCell className="text-xs">{product.sku}</TableCell>
               <TableCell className="font-medium">{product.name}</TableCell>
-              <TableCell>
-                <Input
-                  type="number"
-                  value={product.price}
-                  onChange={(e) =>
-                    onUpdateProduct(product.id, { price: parseFloat(e.target.value) || 0 })
-                  }
-                  className="w-24"
-                />
+              <TableCell className="text-xs">{product.sku}</TableCell>
+              <TableCell className="capitalize text-muted-foreground">
+                {product.status}
               </TableCell>
+              <TableCell>{product.price}</TableCell>
+              <TableCell>{product.color}</TableCell>
+              <TableCell>{product.size}</TableCell>
+              <TableCell>{product.brand}</TableCell>
+              <TableCell>{product.category}</TableCell>
               <TableCell>
-                <Input
-                  value={product.category || ''}
-                  onChange={(e) =>
-                    onUpdateProduct(product.id, { category: e.target.value })
-                  }
-                  className="w-40"
-                />
+                {product.image && (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    src={product.image}
+                    alt={product.name}
+                    className="h-12 w-12 object-cover"
+                  />
+                )}
               </TableCell>
-              <TableCell className="capitalize text-muted-foreground">{product.type}</TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -1,16 +1,23 @@
 import axios from 'axios';
 
+interface WooProductAttribute {
+  name: string;
+  options?: string[];
+  option?: string;
+}
+
 interface WooProductData {
   id: number;
   sku: string;
   name: string;
-  price: number;
+  price: number | string;
   categories?: { name: string }[];
   variations?: unknown[];
   parent_id?: number;
   stock_quantity?: number;
   status?: string;
   images?: { src: string }[];
+  attributes?: WooProductAttribute[];
 }
 
 export type WooProduct = {
@@ -24,6 +31,9 @@ export type WooProduct = {
   stock?: number;
   status?: string;
   image?: string;
+  color?: string;
+  size?: string;
+  brand?: string;
 };
 
 export type WooShop = {
@@ -47,24 +57,70 @@ export function getShopConfigs(): WooShop[] {
   }
 }
 
+function extractAttribute(
+  p: WooProductData,
+  names: string[],
+): string | undefined {
+  const attr = p.attributes?.find((a) =>
+    names.includes(a.name.toLowerCase()),
+  );
+  if (!attr) return undefined;
+  if (attr.option) return attr.option;
+  if (attr.options && attr.options.length > 0) return attr.options[0];
+  return undefined;
+}
+
+function mapProduct(p: WooProductData): WooProduct {
+  return {
+    id: p.id,
+    sku: p.sku,
+    name: p.name,
+    price: typeof p.price === 'string' ? parseFloat(p.price) : p.price,
+    category: p.categories?.[0]?.name,
+    type: 'parent',
+    parentId: p.parent_id || undefined,
+    stock: p.stock_quantity,
+    status: p.status,
+    image: p.images?.[0]?.src,
+    color: extractAttribute(p, ['color', 'colour', 'pa_color', 'farve']),
+    size: extractAttribute(p, ['size', 'pa_size', 'størrelse']),
+    brand: extractAttribute(p, ['brand', 'pa_brand']),
+  };
+}
+
 export async function fetchWooProducts(shop: WooShop): Promise<WooProduct[]> {
   const client = getWooClient(shop);
   try {
-    const res = await client.get('/products');
+    const res = await client.get('/products', { params: { per_page: 100 } });
     const data = res.data as WooProductData[];
-    // Map WooCommerce products to local Product type
-    return data.map((p): WooProduct => ({
-      id: p.id,
-      sku: p.sku,
-      name: p.name,
-      price: p.price,
-      category: p.categories?.[0]?.name,
-      type: p.variations?.length ? 'parent' : 'variation',
-      parentId: p.parent_id || undefined,
-      stock: p.stock_quantity,
-      status: p.status,
-      image: p.images?.[0]?.src,
-    }));
+    const products: WooProduct[] = [];
+
+    for (const p of data) {
+      const base = mapProduct(p);
+      if (p.variations && (p.variations as unknown[]).length > 0) {
+        base.type = 'parent';
+        products.push(base);
+        const varRes = await client.get(
+          `/products/${p.id}/variations`,
+          { params: { per_page: 100 } },
+        );
+        const varData = varRes.data as WooProductData[];
+        for (const v of varData) {
+          const variation = mapProduct(v);
+          variation.type = 'variation';
+          variation.parentId = p.id;
+          variation.category = base.category;
+          if (!variation.brand) variation.brand = base.brand;
+          if (!variation.image) variation.image = base.image;
+          products.push(variation);
+        }
+      } else {
+        base.type = 'parent';
+        products.push(base);
+      }
+    }
+
+    return products;
   } catch (err: unknown) {
     throw err;
   }


### PR DESCRIPTION
## Summary
- add API endpoint to pull WooCommerce products for a given shop
- enhance WooCommerce client to include color, size, brand and variations
- load WooCommerce products on shop selection and show extended product table

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dbee82cbc83339a46983d2f64a4f3