### PR TITLE
feat: add shops persistence

### DIFF
--- a/src/app/api/shops/[id]/route.ts
+++ b/src/app/api/shops/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { db } from '@/lib/db';
+import { shops } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  const [shop] = await db
+    .select()
+    .from(shops)
+    .where(eq(shops.id, params.id));
+  if (!shop) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(shop);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const body = await request.json();
+  await db
+    .update(shops)
+    .set({
+      name: body.name,
+      url: body.url,
+      apiKey: body.apiKey,
+      apiSecret: body.apiSecret,
+      isConnected: body.isConnected ?? false,
+      lastSync: body.lastSync ? new Date(body.lastSync) : null,
+    })
+    .where(eq(shops.id, params.id));
+
+  const [shop] = await db
+    .select()
+    .from(shops)
+    .where(eq(shops.id, params.id));
+  return NextResponse.json(shop);
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string } },
+) {
+  await db.delete(shops).where(eq(shops.id, params.id));
+  return NextResponse.json({ success: true });
+}
+

--- a/src/app/api/shops/route.ts
+++ b/src/app/api/shops/route.ts
@@ -1,16 +1,34 @@
-// src/app/api/shops/route.ts
 import { NextResponse } from 'next/server';
-import type { ShopConfig } from '@/lib/wooApi';
+import { v4 as uuidv4 } from 'uuid';
+import { db } from '@/lib/db';
+import { shops } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
 
 export async function GET() {
-  const raw = process.env.SHOP_CONFIGS;
-  if (!raw) return NextResponse.json([], { status: 200 });
+  const data = await db.select().from(shops);
+  return NextResponse.json(data);
+}
 
+export async function POST(request: Request) {
   try {
-    const shops: ShopConfig[] = JSON.parse(raw);
-    const output = shops.map((s) => ({ id: s.id, name: s.name }));
-    return NextResponse.json(output);
+    const body = await request.json();
+    const id = uuidv4();
+    await db.insert(shops).values({
+      id,
+      name: body.name,
+      url: body.url,
+      apiKey: body.apiKey,
+      apiSecret: body.apiSecret,
+      isConnected: body.isConnected ?? false,
+      lastSync: body.lastSync ? new Date(body.lastSync) : null,
+    });
+    const [shop] = await db
+      .select()
+      .from(shops)
+      .where(eq(shops.id, id));
+    return NextResponse.json(shop, { status: 201 });
   } catch {
-    return NextResponse.json({ error: 'Ugyldig SHOP_CONFIGS' }, { status: 500 });
+    return NextResponse.json({ error: 'Kunne ikke oprette shop' }, { status: 500 });
   }
 }
+

--- a/src/components/ShopSelector.tsx
+++ b/src/components/ShopSelector.tsx
@@ -17,10 +17,16 @@ export function ShopSelector({ selected, onChange }: Props) {
   const [shops, setShops] = useState<Shop[]>([]);
 
   useEffect(() => {
-    fetch('/api/shops')
-      .then((res) => res.json())
-      .then((data) => setShops(data))
-      .catch(() => console.error('Fejl ved hentning af shops'));
+    const loadShops = async () => {
+      try {
+        const res = await fetch('/api/shops');
+        const data: Shop[] = await res.json();
+        setShops(data);
+      } catch {
+        console.error('Fejl ved hentning af shops');
+      }
+    };
+    loadShops();
   }, []);
 
   return (

--- a/src/lib/initDb.ts
+++ b/src/lib/initDb.ts
@@ -20,4 +20,14 @@ export function initDb(db: Database.Database) {
     parent_sku TEXT,
     attributes TEXT
   );`);
+
+  db.exec(`CREATE TABLE IF NOT EXISTS shops (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    url TEXT NOT NULL,
+    api_key TEXT,
+    api_secret TEXT,
+    is_connected INTEGER NOT NULL DEFAULT 0,
+    last_sync INTEGER
+  );`);
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -19,3 +19,13 @@ export const products = sqliteTable('products', {
   parentSku: text('parent_sku'),
   attributes: text('attributes'),
 });
+
+export const shops = sqliteTable('shops', {
+  id: text('id').primaryKey(),
+  name: text('name').notNull(),
+  url: text('url').notNull(),
+  apiKey: text('api_key'),
+  apiSecret: text('api_secret'),
+  isConnected: integer('is_connected', { mode: 'boolean' }).notNull().default(false),
+  lastSync: integer('last_sync', { mode: 'timestamp' }),
+});


### PR DESCRIPTION
## Summary
- add `shops` table to SQLite schema and initialization
- provide CRUD API routes for managing shops
- load and manage shops via API in UI components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dc6a47c58833399f161bd95503fa6