### PR TITLE
Verify API connections on startup

### DIFF
--- a/src/app/api/shops/route.ts
+++ b/src/app/api/shops/route.ts
@@ -3,9 +3,47 @@ import { v4 as uuidv4 } from 'uuid';
 import { db } from '@/lib/db';
 import { shops } from '@/lib/schema';
 import { eq } from 'drizzle-orm';
+import { getWooClient } from '@/lib/wooApi';
 
 export async function GET() {
   const data = await db.select().from(shops);
+
+  await Promise.all(
+    data.map(async (shop) => {
+      if (!shop.apiKey || !shop.apiSecret) {
+        await db
+          .update(shops)
+          .set({ isConnected: false })
+          .where(eq(shops.id, shop.id));
+        shop.isConnected = false;
+        return;
+      }
+
+      const client = getWooClient({
+        id: shop.id,
+        name: shop.name,
+        url: shop.url,
+        consumer_key: shop.apiKey,
+        consumer_secret: shop.apiSecret,
+      });
+
+      try {
+        await client.get('/products', { params: { per_page: 1 } });
+        await db
+          .update(shops)
+          .set({ isConnected: true })
+          .where(eq(shops.id, shop.id));
+        shop.isConnected = true;
+      } catch {
+        await db
+          .update(shops)
+          .set({ isConnected: false })
+          .where(eq(shops.id, shop.id));
+        shop.isConnected = false;
+      }
+    }),
+  );
+
   return NextResponse.json(data);
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import type { WooProduct } from '@/lib/wooApi';
 // Custom toast implementation
@@ -23,19 +23,17 @@ const toast = {
     setTimeout(() => document.body.removeChild(toastEl), 3000);
   }
 };
-import { 
-  Plus, 
-  Settings, 
-  ShoppingBag, 
-  Store, 
-  Edit3, 
-  Trash2, 
-  ChevronDown, 
-  ChevronRight, 
-  Wifi, 
+import {
+  Plus,
+  ShoppingBag,
+  Store,
+  Edit3,
+  Trash2,
+  ChevronDown,
+  ChevronRight,
+  Wifi,
   WifiOff,
   Search,
-  Filter,
   RefreshCw,
   Save,
   X
@@ -63,7 +61,6 @@ export default function WooCommerceManager() {
   const [expandedProducts, setExpandedProducts] = useState<Set<number>>(new Set());
   const [editingShop, setEditingShop] = useState<Shop | null>(null);
   const [showNewShopForm, setShowNewShopForm] = useState(false);
-  const [connectionsChecked, setConnectionsChecked] = useState(false);
 
   // Mock data for demonstration
   useEffect(() => {
@@ -91,12 +88,6 @@ export default function WooCommerceManager() {
     loadShops();
   }, []);
 
-  useEffect(() => {
-    if (!connectionsChecked && shops.length > 0) {
-      setConnectionsChecked(true);
-      shops.forEach((shop) => testConnection(shop, true));
-    }
-  }, [shops, connectionsChecked]);
 
   const filteredProducts = products.filter(product => 
     product.name.toLowerCase().includes(searchTerm.toLowerCase()) ||


### PR DESCRIPTION
## Summary
- check WooCommerce API connections for all shops on backend before returning
- remove redundant client-side connection tests and clean up imports

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688dd0ad5afc8333a15a70040f73b4c8