### PR TITLE
feat: add sale and regular price support

### DIFF
--- a/src/components/ProductTable.tsx
+++ b/src/components/ProductTable.tsx
@@ -21,7 +21,8 @@ export function ProductTable({ products, onToggleSelect }: Props) {
             <TableHead>Navn</TableHead>
             <TableHead>SKU</TableHead>
             <TableHead>Status</TableHead>
-            <TableHead>Pris</TableHead>
+            <TableHead>Normalpris</TableHead>
+            <TableHead>Salgspris</TableHead>
             <TableHead>Farve</TableHead>
             <TableHead>Størrelse</TableHead>
             <TableHead>Brand</TableHead>
@@ -46,7 +47,18 @@ export function ProductTable({ products, onToggleSelect }: Props) {
               <TableCell className="capitalize text-muted-foreground">
                 {product.status}
               </TableCell>
-              <TableCell>{product.price}</TableCell>
+              <TableCell>{product.regularPrice ?? '-'}</TableCell>
+              <TableCell
+                className={
+                  product.salePrice !== undefined &&
+                  product.regularPrice !== undefined &&
+                  product.salePrice < product.regularPrice
+                    ? 'text-red-600 font-semibold'
+                    : undefined
+                }
+              >
+                {product.salePrice ?? '-'}
+              </TableCell>
               <TableCell>{product.color}</TableCell>
               <TableCell>{product.size}</TableCell>
               <TableCell>{product.brand}</TableCell>

--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -11,6 +11,8 @@ interface WooProductData {
   sku: string;
   name: string;
   price: number | string;
+  regular_price?: number | string;
+  sale_price?: number | string;
   categories?: { name: string }[];
   variations?: unknown[];
   parent_id?: number;
@@ -25,6 +27,8 @@ export type WooProduct = {
   sku: string;
   name: string;
   price: number;
+  regularPrice?: number;
+  salePrice?: number;
   category?: string;
   type: 'parent' | 'variation';
   parentId?: number;
@@ -76,6 +80,18 @@ function mapProduct(p: WooProductData): WooProduct {
     sku: p.sku,
     name: p.name,
     price: typeof p.price === 'string' ? parseFloat(p.price) : p.price,
+    regularPrice:
+      p.regular_price !== undefined
+        ? typeof p.regular_price === 'string'
+          ? parseFloat(p.regular_price)
+          : p.regular_price
+        : undefined,
+    salePrice:
+      p.sale_price !== undefined
+        ? typeof p.sale_price === 'string'
+          ? parseFloat(p.sale_price)
+          : p.sale_price
+        : undefined,
     category: p.categories?.[0]?.name,
     type: 'parent',
     parentId: p.parent_id || undefined,


### PR DESCRIPTION
## Summary
- include regular and sale price fields in WooProduct
- map regular and sale prices from WooCommerce API
- display normal and sale prices in product table with sale highlight

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688dd521311c8333bac200fa4e919ceb