### PR TITLE
Return parent Woo products with variation details

### DIFF
--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -46,10 +46,14 @@ export type WooProduct = {
 export type WooProductVariation = {
   id: number;
   sku: string;
+  price: number;
+  regularPrice?: number;
+  salePrice?: number;
   stock?: number;
   stockStatus?: string;
   color?: string;
   size?: string;
+  image?: string;
 };
 
 export type WooShop = {
@@ -142,14 +146,17 @@ export async function fetchWooProducts(shop: WooShop): Promise<WooProduct[]> {
           variation.category = base.category;
           if (!variation.brand) variation.brand = base.brand;
           if (!variation.image) variation.image = base.image;
-          products.push(variation);
           summaries.push({
             id: variation.id,
             sku: variation.sku,
+            price: variation.price,
+            regularPrice: variation.regularPrice,
+            salePrice: variation.salePrice,
             stock: variation.stock,
             stockStatus: variation.stockStatus,
             color: variation.color,
             size: variation.size,
+            image: variation.image,
           });
         }
         base.variations = summaries;


### PR DESCRIPTION
## Summary
- expand `WooProductVariation` to include pricing and image fields
- avoid pushing variation products to the main list, retaining only parent entries
- store full variation info (price, stock, image, etc.) under each parent's `variations` array

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ded4247388333bf3d2d0c07ffc05b