### PR TITLE
feat: add product detail sheet modal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import ProductSheetModal from '@/components/ProductSheetModal';
 import type { WooProduct } from '@/lib/wooApi';
 // Custom toast implementation
 const toast = {
@@ -545,7 +546,7 @@ export default function WooCommerceManager() {
           )}
         </div>
       </div>
-      {showSheet && selectedProduct && <div className="hidden" />}
+      {showSheet && selectedProduct && <ProductSheetModal product={selectedProduct} onClose={() => setShowSheet(false)} />}
     </div>
   );
 }

--- a/src/components/ProductSheet.tsx
+++ b/src/components/ProductSheet.tsx
@@ -1,0 +1,64 @@
+'use client';
+/* eslint-disable @next/next/no-img-element */
+
+import type { WooProduct } from '@/lib/wooApi';
+
+export default function ProductSheet({ product }: { product: WooProduct }) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-start gap-4">
+        {product.image && (
+          <img
+            src={product.image}
+            alt={product.name}
+            className="w-32 h-32 object-cover rounded"
+          />
+        )}
+        <div className="space-y-1">
+          <h2 className="text-xl font-bold">{product.name}</h2>
+          <p className="text-sm text-gray-500">SKU: {product.sku}</p>
+          <p className="text-sm">Pris: {product.price}</p>
+          {typeof product.stock === 'number' && (
+            <p className="text-sm">Lager: {product.stock}</p>
+          )}
+        </div>
+      </div>
+
+      {product.variations && product.variations.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="p-2 text-left">Farve</th>
+                <th className="p-2 text-left">Størrelse</th>
+                <th className="p-2 text-left">Pris</th>
+                <th className="p-2 text-left">Lager</th>
+                <th className="p-2 text-left">Billede</th>
+              </tr>
+            </thead>
+            <tbody>
+              {product.variations.map((v) => (
+                <tr key={v.id} className="border-t">
+                  <td className="p-2">{v.color}</td>
+                  <td className="p-2">{v.size}</td>
+                  <td className="p-2">{v.price}</td>
+                  <td className="p-2">{v.stock}</td>
+                  <td className="p-2">
+                    {v.image && (
+                      <img
+                        src={v.image}
+                        alt={`${product.name} ${v.sku}`}
+                        className="w-12 h-12 object-cover"
+                      />
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/ProductSheetModal.tsx
+++ b/src/components/ProductSheetModal.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { X } from 'lucide-react';
+import type { WooProduct } from '@/lib/wooApi';
+import ProductSheet from './ProductSheet';
+
+export default function ProductSheetModal({ product, onClose }: { product: WooProduct; onClose: () => void }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-4 rounded max-w-2xl w-full relative overflow-y-auto max-h-[90vh]">
+        <button
+          className="absolute top-2 right-2 text-gray-600 hover:text-gray-800"
+          onClick={onClose}
+          aria-label="Close"
+        >
+          <X className="w-4 h-4" />
+        </button>
+        <ProductSheet product={product} />
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `ProductSheet` component to display WooProduct details and variations
- create `ProductSheetModal` overlay with close button
- integrate modal into home page with conditional rendering

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688df02839ec833393257cce2e0acdcb