### PR TITLE
fix: suppress hydration warning

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
     <html lang="en">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        suppressHydrationWarning
       >
         {children}
       </body>


### PR DESCRIPTION
## Summary
- prevent hydration mismatch warnings by ignoring attribute differences on `<body>`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688df43a530c8333af291802378afa65