### PR TITLE
Add dashboard with KPI metrics for webshops

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ShopSelector } from '@/components/ShopSelector';
+import type { WooProduct } from '@/lib/wooApi';
+
+export default function Dashboard() {
+  const [selectedShop, setSelectedShop] = useState<string | null>(null);
+  const [products, setProducts] = useState<WooProduct[]>([]);
+
+  useEffect(() => {
+    if (!selectedShop) return;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/woo/products?shopId=${selectedShop}`);
+        const data: WooProduct[] = await res.json();
+        setProducts(data);
+      } catch {
+        console.error('Fejl ved hentning af produkter');
+      }
+    };
+    load();
+  }, [selectedShop]);
+
+  const lowStockThreshold = 5;
+  const lowStock = products.filter(p => (p.stock ?? 0) < lowStockThreshold).length;
+  const totalProducts = products.length;
+  const totalRevenue = products.reduce((sum, p) => sum + (p.totalSales ?? 0) * p.price, 0);
+  const outOfStock = products.filter(p => (p.stock ?? 0) === 0).length;
+  const avgPrice = totalProducts
+    ? products.reduce((sum, p) => sum + p.price, 0) / totalProducts
+    : 0;
+
+  return (
+    <div className="p-6 space-y-6">
+      <ShopSelector selected={selectedShop} onChange={setSelectedShop} />
+      {selectedShop && (
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <Card>
+            <CardHeader>
+              <CardTitle>Varer med lavt lager</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{lowStock}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Samlet antal produkter</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{totalProducts}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Samlet omsætning</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">
+                {totalRevenue.toLocaleString('da-DK', { style: 'currency', currency: 'DKK' })}
+              </p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Udsolgte varer</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">{outOfStock}</p>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle>Gennemsnitspris</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-2xl font-bold">
+                {avgPrice.toLocaleString('da-DK', { style: 'currency', currency: 'DKK' })}
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -35,7 +36,8 @@ import {
   Search,
   RefreshCw,
   Save,
-  X
+  X,
+  LayoutDashboard,
 } from 'lucide-react';
 
 type Product = WooProduct;
@@ -323,11 +325,18 @@ export default function WooCommerceManager() {
         {/* Navigation Tabs */}
         <div className="bg-white rounded-xl shadow-sm border">
           <div className="flex border-b">
+            <Link
+              href="/dashboard"
+              className="flex items-center gap-2 px-6 py-4 font-medium text-gray-600 hover:text-gray-900 transition-colors"
+            >
+              <LayoutDashboard className="w-5 h-5" />
+              Dashboard
+            </Link>
             <button
               onClick={() => setActiveTab('products')}
               className={`flex items-center gap-2 px-6 py-4 font-medium transition-colors ${
-                activeTab === 'products' 
-                  ? 'text-blue-600 border-b-2 border-blue-600 bg-blue-50' 
+                activeTab === 'products'
+                  ? 'text-blue-600 border-b-2 border-blue-600 bg-blue-50'
                   : 'text-gray-600 hover:text-gray-900'
               }`}
             >

--- a/src/lib/wooApi.ts
+++ b/src/lib/wooApi.ts
@@ -19,6 +19,7 @@ interface WooProductData {
   stock_quantity?: number;
   stock_status?: string;
   status?: string;
+  total_sales?: number;
   images?: { src: string }[];
   attributes?: WooProductAttribute[];
 }
@@ -40,6 +41,7 @@ export type WooProduct = {
   color?: string;
   size?: string;
   brand?: string;
+  totalSales?: number;
   variations?: WooProductVariation[];
 };
 
@@ -54,6 +56,7 @@ export type WooProductVariation = {
   color?: string;
   size?: string;
   image?: string;
+  totalSales?: number;
 };
 
 export type WooShop = {
@@ -118,6 +121,7 @@ function mapProduct(p: WooProductData): WooProduct {
     color: extractAttribute(p, ['color', 'colour', 'pa_color', 'farve']),
     size: extractAttribute(p, ['size', 'pa_size', 'størrelse']),
     brand: extractAttribute(p, ['brand', 'pa_brand']),
+    totalSales: p.total_sales,
   };
 }
 
@@ -157,6 +161,7 @@ export async function fetchWooProducts(shop: WooShop): Promise<WooProduct[]> {
             color: variation.color,
             size: variation.size,
             image: variation.image,
+            totalSales: variation.totalSales,
           });
         }
         base.variations = summaries;


### PR DESCRIPTION
## Summary
- add dashboard page with KPI cards for selected webshop
- enhance WooCommerce API mapping to include total sales
- link dashboard from main navigation

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e1a84db048333bb8a1c6bdcd75d54