### PR TITLE
Handle invalid product responses in dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -17,8 +17,13 @@ export default function Dashboard() {
     const load = async () => {
       try {
         const res = await fetch(`/api/woo/products?shopId=${selectedShop}`);
-        const data: WooProduct[] = await res.json();
-        setProducts(data);
+        const data: unknown = await res.json();
+        if (!res.ok || !Array.isArray(data)) {
+          console.error('Invalid product response', data);
+          setProducts([]);
+          return;
+        }
+        setProducts(data as WooProduct[]);
       } catch {
         console.error('Fejl ved hentning af produkter');
       }


### PR DESCRIPTION
## Summary
- validate `/api/woo/products` response before using
- log invalid responses and reset product list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e58853e548333b036cf58b0219b8d