### PR TITLE
Fix upload history response to return parsed entries

### DIFF
--- a/src/app/api/upload/history/route.ts
+++ b/src/app/api/upload/history/route.ts
@@ -4,6 +4,10 @@ import { uploads } from '@/lib/schema';
 import { desc } from 'drizzle-orm';
 
 export async function GET() {
-  const entries = await db.select().from(uploads).orderBy(desc(uploads.uploadedAt));
+  const rows = await db.select().from(uploads).orderBy(desc(uploads.uploadedAt));
+  const entries = rows.map((u) => ({
+    ...u,
+    content: JSON.parse(u.content),
+  }));
   return NextResponse.json(entries);
 }


### PR DESCRIPTION
## Summary
- parse JSON content in upload history endpoint
- ensure entries are ordered by upload date

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e62fe196c8333968dc2f9ebf80481