### PR TITLE
Add global navigation header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -25,10 +26,30 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
         suppressHydrationWarning
       >
-        {children}
+        <header className="bg-white shadow">
+          <div className="max-w-7xl mx-auto px-4 py-6 flex items-center justify-between">
+            <h1 className="text-2xl font-bold text-gray-900">
+              WooCommerce Product Manager
+            </h1>
+            <nav className="space-x-6 text-gray-700">
+              <Link href="/dashboard" className="hover:text-blue-600">
+                Dashboard
+              </Link>
+              <Link href="/manager?tab=products" className="hover:text-blue-600">
+                Produkter
+              </Link>
+              <Link href="/manager?tab=shops" className="hover:text-blue-600">
+                Shops
+              </Link>
+            </nav>
+          </div>
+        </header>
+        <main className="max-w-7xl mx-auto p-4">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/src/app/manager/page.tsx
+++ b/src/app/manager/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -53,16 +54,25 @@ type Shop = {
 };
 
 export default function WooCommerceManager() {
+  const searchParams = useSearchParams();
+  const initialTab = searchParams.get('tab') === 'shops' ? 'shops' : 'products';
   const [products, setProducts] = useState<Product[]>([]);
   const [shops, setShops] = useState<Shop[]>([]);
   const [selectedShop, setSelectedShop] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [activeTab, setActiveTab] = useState<'products' | 'shops'>('products');
+  const [activeTab, setActiveTab] = useState<'products' | 'shops'>(initialTab);
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
   const [showSheet, setShowSheet] = useState(false);
   const [editingShop, setEditingShop] = useState<Shop | null>(null);
   const [showNewShopForm, setShowNewShopForm] = useState(false);
+
+  useEffect(() => {
+    const tab = searchParams.get('tab');
+    if (tab === 'products' || tab === 'shops') {
+      setActiveTab(tab);
+    }
+  }, [searchParams]);
 
   // Load data from the backend
   useEffect(() => {


### PR DESCRIPTION
## Summary
- add shared header with site title and navigation links to Dashboard, Produkter, Shops
- allow manager page to open specific tab via URL search parameter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688f2a61a49883339857940818e7b374