### PR TITLE
Move shop selector to header

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,22 +1,19 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'next/navigation';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ShopSelector } from '@/components/ShopSelector';
 import type { WooProduct } from '@/lib/wooApi';
+import { useShop } from '@/components/ShopContext';
 
 export default function Dashboard() {
-  const params = useSearchParams();
-  const initialShop = params.get('shopId');
-  const [selectedShop, setSelectedShop] = useState<string | null>(initialShop);
+  const { shopId } = useShop();
   const [products, setProducts] = useState<WooProduct[]>([]);
 
   useEffect(() => {
-    if (!selectedShop) return;
+    if (!shopId) return;
     const load = async () => {
       try {
-        const res = await fetch(`/api/woo/products?shopId=${selectedShop}`);
+        const res = await fetch(`/api/woo/products?shopId=${shopId}`);
         const data: unknown = await res.json();
         if (!res.ok || !Array.isArray(data)) {
           console.error('Invalid product response', data);
@@ -29,13 +26,16 @@ export default function Dashboard() {
       }
     };
     load();
-  }, [selectedShop]);
+  }, [shopId]);
 
   const lowStockThreshold = 5;
-  const lowStock = products.filter(p => (p.stock ?? 0) < lowStockThreshold).length;
+  const lowStock = products.filter((p) => (p.stock ?? 0) < lowStockThreshold).length;
   const totalProducts = products.length;
-  const totalRevenue = products.reduce((sum, p) => sum + (p.totalSales ?? 0) * p.price, 0);
-  const outOfStock = products.filter(p => (p.stock ?? 0) === 0).length;
+  const totalRevenue = products.reduce(
+    (sum, p) => sum + (p.totalSales ?? 0) * p.price,
+    0,
+  );
+  const outOfStock = products.filter((p) => (p.stock ?? 0) === 0).length;
   const avgPrice = totalProducts
     ? products.reduce((sum, p) => sum + p.price, 0) / totalProducts
     : 0;
@@ -46,10 +46,9 @@ export default function Dashboard() {
         <div className="bg-white rounded-xl shadow-sm border p-6">
           <div className="flex items-center justify-between">
             <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
-            <ShopSelector selected={selectedShop} onChange={setSelectedShop} />
           </div>
         </div>
-        {selectedShop && (
+        {shopId && (
           <div className="bg-white rounded-xl shadow-sm border p-6">
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
               <Card>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import { ShopProvider } from "@/components/ShopContext";
+import { ShopSelector } from "@/components/ShopSelector";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -29,27 +31,32 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
         suppressHydrationWarning
       >
-        <header className="bg-white shadow">
-          <div className="max-w-7xl mx-auto px-4 py-6 flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-gray-900">
-              WooCommerce Product Manager
-            </h1>
-            <nav className="space-x-6 text-gray-700">
-              <Link href="/dashboard" className="hover:text-blue-600">
-                Dashboard
-              </Link>
-              <Link href="/manager?tab=products" className="hover:text-blue-600">
-                Produkter
-              </Link>
-              <Link href="/manager?tab=shops" className="hover:text-blue-600">
-                Shops
-              </Link>
-            </nav>
-          </div>
-        </header>
-        <main className="max-w-7xl mx-auto p-4">
-          {children}
-        </main>
+        <ShopProvider>
+          <header className="bg-white shadow">
+            <div className="max-w-7xl mx-auto px-4 py-6 flex items-center justify-between">
+              <h1 className="text-2xl font-bold text-gray-900">
+                WooCommerce Product Manager
+              </h1>
+              <div className="flex items-center space-x-6 text-gray-700">
+                <nav className="space-x-6">
+                  <Link href="/dashboard" className="hover:text-blue-600">
+                    Dashboard
+                  </Link>
+                  <Link href="/manager?tab=products" className="hover:text-blue-600">
+                    Produkter
+                  </Link>
+                  <Link href="/manager?tab=shops" className="hover:text-blue-600">
+                    Shops
+                  </Link>
+                </nav>
+                <ShopSelector />
+              </div>
+            </div>
+          </header>
+          <main className="max-w-7xl mx-auto p-4">
+            {children}
+          </main>
+        </ShopProvider>
       </body>
     </html>
   );

--- a/src/components/ShopContext.tsx
+++ b/src/components/ShopContext.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface ShopContextValue {
+  shopId: string | null;
+  setShopId: (id: string | null) => void;
+}
+
+const ShopContext = createContext<ShopContextValue | undefined>(undefined);
+
+export function ShopProvider({ children }: { children: ReactNode }) {
+  const [shopId, setShopId] = useState<string | null>(null);
+  return (
+    <ShopContext.Provider value={{ shopId, setShopId }}>
+      {children}
+    </ShopContext.Provider>
+  );
+}
+
+export function useShop() {
+  const context = useContext(ShopContext);
+  if (!context) {
+    throw new Error('useShop must be used within a ShopProvider');
+  }
+  return context;
+}
+

--- a/src/components/ShopSelector.tsx
+++ b/src/components/ShopSelector.tsx
@@ -1,6 +1,8 @@
+
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useShop } from './ShopContext';
 import { Label } from '@/components/ui/label';
 
 type Shop = {
@@ -8,12 +10,8 @@ type Shop = {
   name: string;
 };
 
-type Props = {
-  selected: string | null;
-  onChange: (shopId: string) => void;
-};
-
-export function ShopSelector({ selected, onChange }: Props) {
+export function ShopSelector() {
+  const { shopId, setShopId } = useShop();
   const [shops, setShops] = useState<Shop[]>([]);
 
   useEffect(() => {
@@ -30,13 +28,15 @@ export function ShopSelector({ selected, onChange }: Props) {
   }, []);
 
   return (
-    <div className="space-y-1">
-      <Label htmlFor="shop">Vælg webshop</Label>
+    <div className="flex items-center gap-2">
+      <Label htmlFor="shop" className="sr-only">
+        Vælg webshop
+      </Label>
       <select
         id="shop"
         className="w-64 border rounded px-3 py-2"
-        value={selected ?? ''}
-        onChange={(e) => onChange(e.target.value)}
+        value={shopId ?? ''}
+        onChange={(e) => setShopId(e.target.value)}
       >
         <option value="" disabled>
           Vælg en shop

--- a/src/components/SyncClient.tsx
+++ b/src/components/SyncClient.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useState } from 'react';
 import type { WooProduct } from '@/lib/wooApi';
 import { ProductTable } from './ProductTable';
-import { ShopSelector } from './ShopSelector';
 import SyncResultModal from './SyncResultModal';
+import { useShop } from './ShopContext';
 
 type Row = WooProduct & { selected?: boolean };
 
 export default function SyncClient() {
   const [rows, setRows] = useState<Row[]>([]);
-  const [shopId, setShopId] = useState('');
+  const { shopId } = useShop();
   const [loading, setLoading] = useState(false);
   const [result, setResult] = useState<
     null | { sku: string; success: boolean; error?: string }[]
@@ -55,7 +55,6 @@ export default function SyncClient() {
 
   return (
     <div className="space-y-4">
-      <ShopSelector selected={shopId} onChange={setShopId} />
       <ProductTable products={rows} onToggleSelect={toggleRow} />
       <button
         className="border rounded px-4 py-2"


### PR DESCRIPTION
## Summary
- show shop dropdown in global header
- share selected shop via context so pages react to selection

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688faa5db1788333a8680387ae631f04