### PR TITLE
Add header icons and sync controls

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
+import { LayoutDashboard, ShoppingBag, Store } from "lucide-react";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -34,14 +35,17 @@ export default function RootLayout({
             <h1 className="text-2xl font-bold text-gray-900">
               WooCommerce Product Manager
             </h1>
-            <nav className="space-x-6 text-gray-700">
-              <Link href="/dashboard" className="hover:text-blue-600">
+            <nav className="flex space-x-6 text-gray-700">
+              <Link href="/dashboard" className="flex items-center gap-2 hover:text-blue-600">
+                <LayoutDashboard className="w-5 h-5" />
                 Dashboard
               </Link>
-              <Link href="/manager?tab=products" className="hover:text-blue-600">
+              <Link href="/manager?tab=products" className="flex items-center gap-2 hover:text-blue-600">
+                <ShoppingBag className="w-5 h-5" />
                 Produkter
               </Link>
-              <Link href="/manager?tab=shops" className="hover:text-blue-600">
+              <Link href="/manager?tab=shops" className="flex items-center gap-2 hover:text-blue-600">
+                <Store className="w-5 h-5" />
                 Shops
               </Link>
             </nav>

--- a/src/app/manager/page.tsx
+++ b/src/app/manager/page.tsx
@@ -168,7 +168,7 @@ export default function WooCommerceManager() {
         return;
       }
       // Dynamisk import for at undgå SSR-problemer
-      const { fetchWooProducts } = await import('../lib/wooApi');
+      const { fetchWooProducts } = await import('@/lib/wooApi');
       const productsFromApi = await fetchWooProducts({
         id: shop.id,
         name: shop.name,
@@ -328,6 +328,18 @@ export default function WooCommerceManager() {
                   </option>
                 ))}
               </select>
+              <Button
+                onClick={syncProducts}
+                disabled={isLoading || !selectedShop}
+                className="bg-green-600 hover:bg-green-700"
+              >
+                {isLoading ? (
+                  <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <RefreshCw className="w-4 h-4 mr-2" />
+                )}
+                Synkroniser
+              </Button>
             </div>
           </div>
         </div>
@@ -370,7 +382,7 @@ export default function WooCommerceManager() {
           {activeTab === 'products' && (
             <div className="p-6 space-y-6">
               {/* Controls */}
-              <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
+              <div className="flex flex-col sm:flex-row gap-4 items-start sm:items-center">
                 <div className="flex-1 max-w-md">
                   <div className="relative">
                     <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
@@ -381,20 +393,6 @@ export default function WooCommerceManager() {
                       className="pl-10"
                     />
                   </div>
-                </div>
-                <div className="flex gap-2">
-                  <Button 
-                    onClick={syncProducts} 
-                    disabled={isLoading || !selectedShop}
-                    className="bg-green-600 hover:bg-green-700"
-                  >
-                    {isLoading ? (
-                      <RefreshCw className="w-4 h-4 mr-2 animate-spin" />
-                    ) : (
-                      <RefreshCw className="w-4 h-4 mr-2" />
-                    )}
-                    Synkroniser
-                  </Button>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- add meaningful lucide-react icons to header navigation links
- place shop connection indicator and sync button next to shop selector
- fix import path for WooCommerce API helper

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fad7f3c508333982c98b26557aeb7