### PR TITLE
Wrap app with ShopProvider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Link from "next/link";
-import { LayoutDashboard, ShoppingBag, Store } from "lucide-react";
+import { ShopProvider } from "@/components/ShopContext";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -30,27 +30,29 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased bg-gray-50`}
         suppressHydrationWarning
       >
-        <header className="bg-white shadow">
-          <div className="max-w-7xl mx-auto px-4 py-6 flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-gray-900">
-              WooCommerce Product Manager
-            </h1>
-            <nav className="space-x-6 text-gray-700">
-              <Link href="/dashboard" className="hover:text-blue-600">
-                Dashboard
-              </Link>
-              <Link href="/manager?tab=products" className="hover:text-blue-600">
-                Produkter
-              </Link>
-              <Link href="/manager?tab=shops" className="hover:text-blue-600">
-                Shops
-              </Link>
-            </nav>
-          </div>
-        </header>
-        <main className="max-w-7xl mx-auto p-4">
-          {children}
-        </main>
+        <ShopProvider>
+          <header className="bg-white shadow">
+            <div className="max-w-7xl mx-auto px-4 py-6 flex items-center justify-between">
+              <h1 className="text-2xl font-bold text-gray-900">
+                WooCommerce Product Manager
+              </h1>
+              <nav className="space-x-6 text-gray-700">
+                <Link href="/dashboard" className="hover:text-blue-600">
+                  Dashboard
+                </Link>
+                <Link href="/manager?tab=products" className="hover:text-blue-600">
+                  Produkter
+                </Link>
+                <Link href="/manager?tab=shops" className="hover:text-blue-600">
+                  Shops
+                </Link>
+              </nav>
+            </div>
+          </header>
+          <main className="max-w-7xl mx-auto p-4">
+            {children}
+          </main>
+        </ShopProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- wrap layout with `ShopProvider` so `useShop` hook has context

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688fc1d2c21883339a5d71c3288c4d72